### PR TITLE
feat: stop showing hinting arrow when inventory is full

### DIFF
--- a/packages/trashy_road/lib/src/game/entities/player/behaviors/player_hinting_behavior.dart
+++ b/packages/trashy_road/lib/src/game/entities/player/behaviors/player_hinting_behavior.dart
@@ -115,6 +115,10 @@ class PlayerHintingBehavior extends Behavior<Player>
       return;
     }
 
+    if (bloc.state.inventory.isFull) {
+      return;
+    }
+
     _lastVisibleTrash = _isTrashVisible ? 0 : _lastVisibleTrash + dt;
     _lastHint += dt;
 


### PR DESCRIPTION
Resolves #16